### PR TITLE
fix: bundle install logic

### DIFF
--- a/gov-start-psm-permit.json
+++ b/gov-start-psm-permit.json
@@ -25,8 +25,7 @@
       "mintHolder": "zoe",
       "contractGovernor": "zoe",
       "psm": "zoe"
-    },
-    "produce": "makeCoreProposalBehavior"
+    }
   },
   "produce": {
     "testFirstAnchorKit": true,

--- a/gov-start-usdc-psm.js
+++ b/gov-start-usdc-psm.js
@@ -15,16 +15,7 @@ const getManifestCall = harden([
       keyword: "USDC",
       proposedName: "USDC",
     },
-    installKeys: {
-      mintHolder: {
-        bundleID:
-          "b1-b183edd918de93c0b009b0f662502ff851c8e95177c812f2eabc82cd65c2c53e1cb12c56719d6e7c474a0f3d58d3c3d2839dfbf0c2e62f6ee6758e16c16b38c2",
-      },
-      psm: {
-        bundleID:
-          "b1-c25fbc404ae239a8bf9f3d5f65f3f27d489fb4c8e48de0613b1c59c6fc00718243b2c84a3d7060350cbe4442d340d4826d4d1948b9e9938b31807e64c18adbc4",
-      },
-    },
+    installKeys: {},
   },
 ]);
 const overrideManifest = {
@@ -97,7 +88,7 @@ const overrideManifest = {
   overrideManifest,
   E,
   log = console.info,
-  restoreRef: overrideRestoreRef,
+  restoreRef = () => {},
 }) => {
   const { entries, fromEntries } = Object;
 
@@ -127,19 +118,6 @@ const overrideManifest = {
       },
     } = allPowers;
     const [exportedGetManifest, ...manifestArgs] = getManifestCall;
-
-    const defaultRestoreRef = async (ref) => {
-      // extract-proposal.js creates these records, and bundleName is
-      // the name under which the bundle was installed into
-      // config.bundles
-      const p = ref.bundleName
-        ? E(vatAdminSvc).getBundleIDByName(ref.bundleName)
-        : ref.bundleID;
-      const bundleID = await p;
-      const label = bundleID.slice(0, 8);
-      return E(zoe).installBundleID(bundleID, label);
-    };
-    const restoreRef = overrideRestoreRef || defaultRestoreRef;
 
     // Get the on-chain installation containing the manifest and behaviors.
     console.info("evaluateBundleCap", {

--- a/gov-start-usdc-psm.js
+++ b/gov-start-usdc-psm.js
@@ -120,9 +120,8 @@ const overrideManifest = {
     // NOTE: If updating any of these names extracted from `allPowers`, you must
     // change `permits` above to reflect their accessibility.
     const {
-      consume: { vatAdminSvc, zoe, agoricNamesAdmin },
+      consume: { vatAdminSvc, zoe },
       evaluateBundleCap,
-      installation: { produce: produceInstallations },
       modules: {
         utils: { runModuleBehaviors },
       },
@@ -162,28 +161,14 @@ const overrideManifest = {
       exportedGetManifest,
       behaviors: Object.keys(manifestNS),
     });
-    const {
-      manifest,
-      options: rawOptions,
-      installations: rawInstallations,
-    } = await manifestNS[exportedGetManifest](
-      harden({ restoreRef }),
-      ...manifestArgs
-    );
+    const { manifest, options: rawOptions } = await manifestNS[
+      exportedGetManifest
+    ](harden({ restoreRef }), ...manifestArgs);
 
-    // Await references in the options or installations.
-    const [options, installations] = await Promise.all(
-      [rawOptions, rawInstallations].map(shallowlyFulfilled)
-    );
+    const options = await shallowlyFulfilled(rawOptions);
 
+    // @skip, these bundles are already installed
     // Publish the installations for behavior dependencies.
-    const installAdmin = E(agoricNamesAdmin).lookupAdmin("installation");
-    await Promise.all(
-      entries(installations || {}).map(([key, value]) => {
-        produceInstallations[key].resolve(value);
-        return E(installAdmin).update(key, value);
-      })
-    );
 
     // Evaluate the manifest for our behaviors.
     return runModuleBehaviors({

--- a/gov-start-usdc-psm.js
+++ b/gov-start-usdc-psm.js
@@ -145,8 +145,7 @@ const overrideManifest = {
 
     const options = await shallowlyFulfilled(rawOptions);
 
-    // @skip, these bundles are already installed
-    // Publish the installations for behavior dependencies.
+    // All dependency bundles are already installed, so we ignore `installations` from the getManifest response.
 
     // Evaluate the manifest for our behaviors.
     return runModuleBehaviors({

--- a/gov-start-usdt-psm.js
+++ b/gov-start-usdt-psm.js
@@ -120,9 +120,8 @@ const overrideManifest = {
     // NOTE: If updating any of these names extracted from `allPowers`, you must
     // change `permits` above to reflect their accessibility.
     const {
-      consume: { vatAdminSvc, zoe, agoricNamesAdmin },
+      consume: { vatAdminSvc, zoe },
       evaluateBundleCap,
-      installation: { produce: produceInstallations },
       modules: {
         utils: { runModuleBehaviors },
       },
@@ -162,28 +161,14 @@ const overrideManifest = {
       exportedGetManifest,
       behaviors: Object.keys(manifestNS),
     });
-    const {
-      manifest,
-      options: rawOptions,
-      installations: rawInstallations,
-    } = await manifestNS[exportedGetManifest](
-      harden({ restoreRef }),
-      ...manifestArgs
-    );
+    const { manifest, options: rawOptions } = await manifestNS[
+      exportedGetManifest
+    ](harden({ restoreRef }), ...manifestArgs);
 
-    // Await references in the options or installations.
-    const [options, installations] = await Promise.all(
-      [rawOptions, rawInstallations].map(shallowlyFulfilled)
-    );
+    const options = await shallowlyFulfilled(rawOptions);
 
+    // @skip, these bundles are already installed
     // Publish the installations for behavior dependencies.
-    const installAdmin = E(agoricNamesAdmin).lookupAdmin("installation");
-    await Promise.all(
-      entries(installations || {}).map(([key, value]) => {
-        produceInstallations[key].resolve(value);
-        return E(installAdmin).update(key, value);
-      })
-    );
 
     // Evaluate the manifest for our behaviors.
     return runModuleBehaviors({

--- a/gov-start-usdt-psm.js
+++ b/gov-start-usdt-psm.js
@@ -15,16 +15,7 @@ const getManifestCall = harden([
       keyword: "USDT",
       proposedName: "USDT",
     },
-    installKeys: {
-      mintHolder: {
-        bundleID:
-          "b1-b183edd918de93c0b009b0f662502ff851c8e95177c812f2eabc82cd65c2c53e1cb12c56719d6e7c474a0f3d58d3c3d2839dfbf0c2e62f6ee6758e16c16b38c2",
-      },
-      psm: {
-        bundleID:
-          "b1-c25fbc404ae239a8bf9f3d5f65f3f27d489fb4c8e48de0613b1c59c6fc00718243b2c84a3d7060350cbe4442d340d4826d4d1948b9e9938b31807e64c18adbc4",
-      },
-    },
+    installKeys: {},
   },
 ]);
 const overrideManifest = {
@@ -97,7 +88,7 @@ const overrideManifest = {
   overrideManifest,
   E,
   log = console.info,
-  restoreRef: overrideRestoreRef,
+  restoreRef = () => {},
 }) => {
   const { entries, fromEntries } = Object;
 
@@ -127,19 +118,6 @@ const overrideManifest = {
       },
     } = allPowers;
     const [exportedGetManifest, ...manifestArgs] = getManifestCall;
-
-    const defaultRestoreRef = async (ref) => {
-      // extract-proposal.js creates these records, and bundleName is
-      // the name under which the bundle was installed into
-      // config.bundles
-      const p = ref.bundleName
-        ? E(vatAdminSvc).getBundleIDByName(ref.bundleName)
-        : ref.bundleID;
-      const bundleID = await p;
-      const label = bundleID.slice(0, 8);
-      return E(zoe).installBundleID(bundleID, label);
-    };
-    const restoreRef = overrideRestoreRef || defaultRestoreRef;
 
     // Get the on-chain installation containing the manifest and behaviors.
     console.info("evaluateBundleCap", {

--- a/gov-start-usdt-psm.js
+++ b/gov-start-usdt-psm.js
@@ -145,8 +145,7 @@ const overrideManifest = {
 
     const options = await shallowlyFulfilled(rawOptions);
 
-    // @skip, these bundles are already installed
-    // Publish the installations for behavior dependencies.
+    // All dependency bundles are already installed, so we ignore `installations` from the getManifest response.
 
     // Evaluate the manifest for our behaviors.
     return runModuleBehaviors({


### PR DESCRIPTION
- see #4 

### Changes

- ensure proposal does not produce any installations, fixing behavior where - 1) the chain would result in 2 installations of the same bundle 2) the agoricNames.installation ref can only hold one value, and would be overriden for previous installations

- removes agoricNamesAdmin from proposal, but leaves in permit as it's needed in  https://github.com/Agoric/agoric-sdk/blob/5387e35d7826329e6d93b3e80b3ed1779887ba82/packages/inter-protocol/src/proposals/startPSM.js#L128



### Testing

```bash
2023-10-26T17:16:49.268Z block-manager: block 72426 begin
2023-10-26T17:16:49.271Z block-manager: block 72426 commit
2023-10-26T17:16:50.281Z block-manager: block 72427 begin
2023-10-26T17:16:50.302Z SwingSet: vat: v1: evaluateBundleCap { manifestBundleRef: { bundleID: 'b1-4c34c89b707bc8ece5a41e97e6a354081f7ae8a40391f1462848348613dd1218dcce574b3e30901a9825a966cb85bda6a92ba9f9ce9ba325e4c475f9a678b930' }, exportedGetManifest: 'getManifestForPsm', vatAdminSvc: Promise [Promise] {} }
2023-10-26T17:16:50.957Z SwingSet: vat: v1: execute { exportedGetManifest: 'getManifestForPsm', behaviors: [ 'INVITE_PSM_COMMITTEE_MANIFEST', 'PSM_MANIFEST', 'getManifestForPsm', 'getManifestForPsmGovernance', 'inviteCommitteeMembers', 'inviteToEconCharter', 'makeAnchorAsset', 'startEconCharter', 'startPSM' ] }
2023-10-26T17:16:50.960Z SwingSet: vat: v1: coreProposal: makeAnchorAsset
2023-10-26T17:16:50.960Z SwingSet: vat: v1: coreProposal: startPSM
2023-10-26T17:16:52.761Z block-manager: block 72427 commit
2023-10-26T17:16:52.915Z block-manager: block 72428 begin
2023-10-26T17:16:53.167Z SwingSet: vat: v28: provisionPool notified of new asset Object [Alleged: USDC brand] {}
2023-10-26T17:16:53.178Z SwingSet: vat: v43: ----- WltFct.4  13 registering asset USDC
2023-10-26T17:16:54.664Z SwingSet: vat: v28: provisionPool balance update { brand: Object [Alleged: USDC brand] {}, value: 0n }
2023-10-26T17:16:56.372Z SwingSet: vat: v58: PSM Starting Object [Alleged: USDC brand] {} { denominator: { brand: Object [Alleged: IST brand] {}, value: 1_000_000n }, numerator: { brand: Object [Alleged: USDC brand] {}, value: 1_000_000n } }
2023-10-26T17:16:56.950Z SwingSet: vat: v15: charter: adding instance psm-IST-USDC
2023-10-26T17:16:57.017Z block-manager: block 72428 commit
2023-10-26T17:16:57.198Z block-manager: block 72429 begin
2023-10-26T17:16:57.237Z block-manager: block 72429 commit
2023-10-26T17:16:58.210Z block-manager: block 72430 begin

```